### PR TITLE
Test promise rejection if response is not 200 ok when performing a GET.

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -14,4 +14,4 @@ module.exports = function(url, options) {
     xhr.open('GET', url);
     xhr.send();
   });
-}
+};

--- a/tests/get.js
+++ b/tests/get.js
@@ -7,17 +7,27 @@ chai.use(chaiAsPromised);
 
 describe('get-test', function() {
   describe('promise should resolve with response',  function() {
-
     before(function () {
       global.XMLHttpRequest = require('xhr2');
     });
-
-    it('should fetch json from server and resolve successfully', function() {
+    it('resolve when response is 200 OK', function() {
       var res = get('https://github.com/hrishikeshs/ajax-as-promised/graphs/contributors-data')
             .then(function(response) {
               return response[0].author && response[0].author.login;
             });
       res.should.eventually.equal('hrishikeshs');
+    });
+  });
+    
+  describe('promise should reject with error', function() {
+    it('reject when response is not 200 OK', function() {
+      var res = get('https://github.com/hrishikeshs.json')
+            .then(function resolve(response) {
+              return response;
+            }, function reject(response) {
+              throw new Error({msg: "promise rejected"});
+            });
+      return res.should.be.rejected;
     });
   });
 });


### PR DESCRIPTION
Use github's api endpoint to test when we receive a response which is not `200 OK` so we can test promise rejection.
